### PR TITLE
Renaming the package to use org scope

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@1.4.0/schema.json",
-  "changelog": ["@changesets/changelog-github", {"repo": "primer/stylelint-config-primer"}],
+  "changelog": ["@changesets/changelog-github", {"repo": "primer/stylelint-config"}],
   "commit": false,
   "linked": [],
   "access": "public",

--- a/.changeset/nervous-geckos-remain.md
+++ b/.changeset/nervous-geckos-remain.md
@@ -1,0 +1,5 @@
+---
+"@primer/stylelint-config": major
+---
+
+Renaming the package to use org scope. This is a breaking change, you'll need to uninstall `stylelint-config-primer` and reinstall `@primer/stylelint-config`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   release:
     name: Final
-    if: ${{ github.repository == 'primer/stylelint-config-primer' }}
+    if: ${{ github.repository == 'primer/stylelint-config' }}
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release_canary.yml
+++ b/.github/workflows/release_canary.yml
@@ -1,0 +1,61 @@
+name: Release
+on:
+  push:
+    branches-ignore:
+      - 'main'
+      - 'changeset-release/**'
+      - 'dependabot/**'
+
+jobs:
+  release-canary:
+    name: Canary
+    if: ${{ github.repository == 'primer/stylelint-config' }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Create .npmrc
+        run: |
+          cat << EOF > "$HOME/.npmrc"
+            //registry.npmjs.org/:_authToken=$NPM_TOKEN
+          EOF
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN_SHARED }}
+
+      - name: Publish canary version
+        run: |
+          echo "$( jq '.version = "0.0.0"' package.json )" > package.json
+          echo -e "---\n'@primer/stylelint-config': patch\n---\n\nFake entry to force publishing" > .changeset/force-snapshot-release.md
+          rm -f .changeset/pre.json
+          yarn changeset version --snapshot
+          yarn changeset publish --tag canary
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Output canary version number
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const package = require(`${process.env.GITHUB_WORKSPACE}/package.json`)
+            github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.sha,
+              state: 'success',
+              context: `Published ${package.name}`,
+              description: package.version,
+              target_url: `https://unpkg.com/${package.name}@${package.version}/`
+            })

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   release-candidate:
     name: Candidate
-    if: ${{ github.repository == 'primer/stylelint-config-primer' }}
+    if: ${{ github.repository == 'primer/stylelint-config' }}
 
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,57 +4,57 @@
 
 ### Patch Changes
 
-- [`3a4654b`](https://github.com/primer/stylelint-config-primer/commit/3a4654b1b7920d71e1284ff78a3bedff932e66a3) [#111](https://github.com/primer/stylelint-config-primer/pull/111) Thanks [@jonrohan](https://github.com/jonrohan)! - Fixing the primer/colors and primer/borders rules
+- [`3a4654b`](https://github.com/primer/stylelint-config/commit/3a4654b1b7920d71e1284ff78a3bedff932e66a3) [#111](https://github.com/primer/stylelint-config/pull/111) Thanks [@jonrohan](https://github.com/jonrohan)! - Fixing the primer/colors and primer/borders rules
 
 ## 11.1.0
 
 ### Minor Changes
 
-- [`e83f61c`](https://github.com/primer/stylelint-config-primer/commit/e83f61cef3bf1df1d9420662594040efdcb86c89) [#99](https://github.com/primer/stylelint-config-primer/pull/99) Thanks [@jonrohan](https://github.com/jonrohan)! - Create a `no-deprecated-colors` rule that looks for deprecated css color variables from primer/primitives.
+- [`e83f61c`](https://github.com/primer/stylelint-config/commit/e83f61cef3bf1df1d9420662594040efdcb86c89) [#99](https://github.com/primer/stylelint-config/pull/99) Thanks [@jonrohan](https://github.com/jonrohan)! - Create a `no-deprecated-colors` rule that looks for deprecated css color variables from primer/primitives.
 
 ### Patch Changes
 
-- [`581f40a`](https://github.com/primer/stylelint-config-primer/commit/581f40a4aacb45db5426b82d4a2434e81eb032e2) [#105](https://github.com/primer/stylelint-config-primer/pull/105) Thanks [@jonrohan](https://github.com/jonrohan)! - Adding reporting to the linter to know how many variables are replaced
+- [`581f40a`](https://github.com/primer/stylelint-config/commit/581f40a4aacb45db5426b82d4a2434e81eb032e2) [#105](https://github.com/primer/stylelint-config/pull/105) Thanks [@jonrohan](https://github.com/jonrohan)! - Adding reporting to the linter to know how many variables are replaced
 
 ## 10.0.1
 
 ### Patch Changes
 
-- [`aa76171`](https://github.com/primer/stylelint-config-primer/commit/aa76171fc5c9c308fcd9d7f7285c8fbdb2c18a7b) [#90](https://github.com/primer/stylelint-config-primer/pull/90) Thanks [@jonrohan](https://github.com/jonrohan)! - Updating the no-undefined-variables lint for the new color-variables mixin.
+- [`aa76171`](https://github.com/primer/stylelint-config/commit/aa76171fc5c9c308fcd9d7f7285c8fbdb2c18a7b) [#90](https://github.com/primer/stylelint-config/pull/90) Thanks [@jonrohan](https://github.com/jonrohan)! - Updating the no-undefined-variables lint for the new color-variables mixin.
 
 ## 10.0.0
 
 ### Major Changes
 
-- [`23a1f15`](https://github.com/primer/stylelint-config-primer/commit/23a1f1599673f2a4f9f28c39da61f42871c05697) [#85](https://github.com/primer/stylelint-config-primer/pull/85) Thanks [@koddsson](https://github.com/koddsson)! - Replace deprecated "blacklist" rules for "dissallow list" rules.
+- [`23a1f15`](https://github.com/primer/stylelint-config/commit/23a1f1599673f2a4f9f28c39da61f42871c05697) [#85](https://github.com/primer/stylelint-config/pull/85) Thanks [@koddsson](https://github.com/koddsson)! - Replace deprecated "blacklist" rules for "dissallow list" rules.
 
   See https://stylelint.io/user-guide/rules/at-rule-blacklist and http://stylelint.io/user-guide/rules/declaration-property-value-disallowed-list/
 
 ### Patch Changes
 
-- [`40d9bb8`](https://github.com/primer/stylelint-config-primer/commit/40d9bb867194ae4335846953b5d8706dc7dc7d79) [#86](https://github.com/primer/stylelint-config-primer/pull/86) Thanks [@koddsson](https://github.com/koddsson)! - Allow rules to optionally display a URL with their message.
+- [`40d9bb8`](https://github.com/primer/stylelint-config/commit/40d9bb867194ae4335846953b5d8706dc7dc7d79) [#86](https://github.com/primer/stylelint-config/pull/86) Thanks [@koddsson](https://github.com/koddsson)! - Allow rules to optionally display a URL with their message.
 
 ## 9.3.3
 
 ### Patch Changes
 
-- [`a339c69`](https://github.com/primer/stylelint-config-primer/commit/a339c698b9ba7ccd01b8cb773dad7a3a14dd13a1) [#81](https://github.com/primer/stylelint-config-primer/pull/81) Thanks [@BinaryMuse](https://github.com/BinaryMuse)! - Update globby to v11
+- [`a339c69`](https://github.com/primer/stylelint-config/commit/a339c698b9ba7ccd01b8cb773dad7a3a14dd13a1) [#81](https://github.com/primer/stylelint-config/pull/81) Thanks [@BinaryMuse](https://github.com/BinaryMuse)! - Update globby to v11
 
 ## 9.3.2
 
 ### Patch Changes
 
-- [`d18cfbf`](https://github.com/primer/stylelint-config-primer/commit/d18cfbfefc25be6ae38f73132552d2f3c62c4d02) [#79](https://github.com/primer/stylelint-config-primer/pull/79) Thanks [@BinaryMuse](https://github.com/BinaryMuse)! - Add additinal verbose logging to `no-undefined-vars`
+- [`d18cfbf`](https://github.com/primer/stylelint-config/commit/d18cfbfefc25be6ae38f73132552d2f3c62c4d02) [#79](https://github.com/primer/stylelint-config/pull/79) Thanks [@BinaryMuse](https://github.com/BinaryMuse)! - Add additinal verbose logging to `no-undefined-vars`
 
-* [`d18cfbf`](https://github.com/primer/stylelint-config-primer/commit/d18cfbfefc25be6ae38f73132552d2f3c62c4d02) [#79](https://github.com/primer/stylelint-config-primer/pull/79) Thanks [@BinaryMuse](https://github.com/BinaryMuse)! - Fix handling of edge-cases in `no-undefined-vars`
+* [`d18cfbf`](https://github.com/primer/stylelint-config/commit/d18cfbfefc25be6ae38f73132552d2f3c62c4d02) [#79](https://github.com/primer/stylelint-config/pull/79) Thanks [@BinaryMuse](https://github.com/BinaryMuse)! - Fix handling of edge-cases in `no-undefined-vars`
 
-- [`bb07673`](https://github.com/primer/stylelint-config-primer/commit/bb076732aa216fcb56e411b8dd7477efc89f7f8a) [#76](https://github.com/primer/stylelint-config-primer/pull/76) Thanks [@BinaryMuse](https://github.com/BinaryMuse)! - Set the default verbose option for `no-scale-colors` to false
+- [`bb07673`](https://github.com/primer/stylelint-config/commit/bb076732aa216fcb56e411b8dd7477efc89f7f8a) [#76](https://github.com/primer/stylelint-config/pull/76) Thanks [@BinaryMuse](https://github.com/BinaryMuse)! - Set the default verbose option for `no-scale-colors` to false
 
 ## 9.3.1
 
 ### Patch Changes
 
-- [`df11e2d`](https://github.com/primer/stylelint-config-primer/commit/df11e2d912913346e0499f7eac901cdfcb83f38c) [#74](https://github.com/primer/stylelint-config-primer/pull/74) Thanks [@BinaryMuse](https://github.com/BinaryMuse)! - Add primer/no-scale-colors to the list of exported plugins
+- [`df11e2d`](https://github.com/primer/stylelint-config/commit/df11e2d912913346e0499f7eac901cdfcb83f38c) [#74](https://github.com/primer/stylelint-config/pull/74) Thanks [@BinaryMuse](https://github.com/BinaryMuse)! - Add primer/no-scale-colors to the list of exported plugins
 
 ## 9.2.1
 
@@ -98,7 +98,7 @@
 - It's also now possible to provide rule _overrides_ in local stylelint configs as functions:
   ```js
   module.exports = {
-    extends: 'stylelint-config-primer',
+    extends: '@primer/stylelint-config',
     rules: {
       'primer/colors': [true, {
         rules: ({variables, rules}) => {
@@ -140,7 +140,7 @@ The rest of the changes should not introduce new linting errors:
 ## 1.4.0
 
 - Updated: Development dependencies are any version `*`
-- Removed: `selector-class-pattern` from config. https://github.com/primer/stylelint-config-primer/pull/11
+- Removed: `selector-class-pattern` from config. https://github.com/primer/stylelint-config/pull/11
 
 ## 1.3.0
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Primer Stylelint Config
 
-[![npm version](https://img.shields.io/npm/v/stylelint-config-primer.svg)](https://www.npmjs.org/package/stylelint-config-primer)
+[![npm version](https://img.shields.io/npm/v/@primer/stylelint-config.svg)](https://www.npmjs.org/package/@primer/stylelint-config)
 
 > A sharable stylelint config object that enforces GitHub's CSS rules
 
 ## Install
 
 ```
-$ npm install --save --dev stylelint-config-primer
+$ npm install --save --dev @primer/stylelint-config
 ```
 
 ## Usage
@@ -16,7 +16,7 @@ Within your [stylelint config object](http://stylelint.io/user-guide/configurati
 
 ```json
 {
-  "extends": "stylelint-config-primer"
+  "extends": "@primer/stylelint-config"
 }
 ```
 
@@ -24,7 +24,7 @@ Within your [stylelint config object](http://stylelint.io/user-guide/configurati
 
 ### Plugins
 
-- [stylelint-order](https://github.com/hudochenkov/stylelint-order): Order-related linting rules for stylelint. Properties must be [sorted according to this list](https://github.com/primer/stylelint-config-primer/blob/main/property-order.js).
+- [stylelint-order](https://github.com/hudochenkov/stylelint-order): Order-related linting rules for stylelint. Properties must be [sorted according to this list](https://github.com/primer/stylelint-config/blob/main/property-order.js).
 - [stylelint-scss](https://github.com/kristerkari/stylelint-scss): A collection of SCSS specific linting rules for stylelint
   - [scss/selector-no-redundant-nesting-selector](https://github.com/kristerkari/stylelint-scss/blob/master/src/rules/selector-no-redundant-nesting-selector/README.md): Disallow redundant nesting selectors (`&`).
 - [primer/no-override](./plugins/#primerno-override): Prohibits custom styles that target Primer CSS selectors.

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -4,7 +4,7 @@ const SAFE_SCSS_EXAMPLE = `
   .Component { color: $gray-500; }
 `
 
-describe('stylelint-config-primer', () => {
+describe('stylelint-config', () => {
   it('stylelint runs with our config', () => {
     return lint('.bold { font-weight: bold; }').then(data => {
       expect(data).not.toHaveErrored()

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "stylelint-config-primer",
+  "name": "@primer/stylelint-config",
   "version": "11.1.1",
   "description": "Sharable stylelint config used by GitHub's CSS",
   "homepage": "http://primer.style/css/tools/linting",
   "author": "GitHub, Inc.",
   "license": "MIT",
   "main": "index.js",
-  "repository": "primer/stylelint-config-primer",
+  "repository": "primer/stylelint-config",
   "keywords": [
     "github",
     "primer",

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -24,14 +24,14 @@ These were intended for use with [Primer CSS] and GitHub projects, but you may f
 
 ## Usage
 
-If you're using or extending `stylelint-config-primer` already, then you're using all of these plugins by default. See [`index.js`](../index.js) for the config defaults.
+If you're using or extending `@primer/stylelint-config` already, then you're using all of these plugins by default. See [`index.js`](../index.js) for the config defaults.
 
-If you're _not_ using or extending `stylelint-config-primer`, you can still reference the plugins by referencing their module paths like so:
+If you're _not_ using or extending `@primer/stylelint-config`, you can still reference the plugins by referencing their module paths like so:
 
 ```js
 // stylelint.config.js
 module.exports = {
-  plugins: ['stylelint-config-primer/plugins/no-override', 'stylelint-config-primer/plugins/no-unused-vars']
+  plugins: ['@primer/stylelint-config/plugins/no-override', '@primer/stylelint-config/plugins/no-unused-vars']
 }
 ```
 
@@ -318,7 +318,7 @@ All variable rules respect the following rule options, as in:
 ```js
 // stylelint.config.js
 module.exports = {
-  extends: 'stylelint-config-primer',
+  extends: '@primer/stylelint-config',
   rules: {
     'primer/colors': [true /* options here */]
     /*                ↑

--- a/plugins/no-override.js
+++ b/plugins/no-override.js
@@ -62,7 +62,7 @@ module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}) => {
         : '(not an array)'
       result.warn(`The "bundles" option must be an array of valid bundles; got: ${invalidBundles}`, {
         stylelintType: 'invalidOption',
-        stylelintReference: 'https://github.com/primer/stylelint-config-primer#options'
+        stylelintReference: 'https://github.com/primer/stylelint-config#options'
       })
     }
 


### PR DESCRIPTION
I wanted to rename the package to use our primer org scope. This package was made before we had the org scoping and we never moved it into the main org. 

@colebemis Since you renamed the react package recently, can you help me not forget any important steps in this process?