### PR TITLE
Truning off scss/dollar-variable-default

### DIFF
--- a/.changeset/mean-pillows-provide.md
+++ b/.changeset/mean-pillows-provide.md
@@ -1,0 +1,5 @@
+---
+"@primer/stylelint-config": patch
+---
+
+Truning off scss/dollar-variable-default

--- a/index.js
+++ b/index.js
@@ -69,7 +69,6 @@ module.exports = {
     'scss/at-extend-no-missing-placeholder': true,
     'scss/at-rule-no-unknown': true,
     'scss/declaration-nested-properties-no-divided-groups': true,
-    'scss/dollar-variable-default': [true, {ignore: 'local'}],
     'scss/dollar-variable-no-missing-interpolation': true,
     'scss/function-quote-no-quoted-strings-inside': true,
     'scss/function-unquote-no-unquoted-strings-inside': true,


### PR DESCRIPTION
This removes the [scss/dollar-variable-default](https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/dollar-variable-default/README.md) rule in the config. 

We had this rule turned on for primer/css, but after pulling in here and testing on our custom css codebase, I think it's better if we don't use it anymore. Especially since primer/css is moving toward using more of primer/primitives.