### PR TITLE
Remove primer-css dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "tap-map": "^1.0.0"
   },
   "peerDependencies": {
-    "@primer/css": ">= 18.0.0",
     "@primer/primitives": ">= 6.0.0",
     "stylelint": ">= 14.0.0"
   },
@@ -46,7 +45,6 @@
     "@changesets/changelog-github": "0.4.2",
     "@changesets/cli": "2.19.0",
     "@github/prettier-config": "0.0.4",
-    "@primer/css": "^19.0.0",
     "@primer/primitives": "^7.0.1",
     "dedent": "0.7.0",
     "eslint": "8.5.0",
@@ -55,6 +53,7 @@
     "eslint-plugin-prettier": "4.0.0",
     "jest": "27.4.5",
     "jest-preset-stylelint": "4.2.0",
+    "postcss": "8.4.5",
     "prettier": "2.5.1",
     "stylelint": "14.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -773,17 +773,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@primer/css@^19.0.0":
-  version "19.1.1"
-  resolved "https://registry.yarnpkg.com/@primer/css/-/css-19.1.1.tgz#c05a2fc5e5f6950472b4ff3bdd70cda6fe1c13f1"
-  integrity sha512-QVwdNOJsLxOD6eTR5LDIdLWg2SIy+eZWMK4ywlLd8qZXJCngtJyTNO5PtSzgs0D9jlMS+dzxvlOOV6GcfLu1hw==
-  dependencies:
-    "@primer/primitives" "^7.2.0"
-
-"@primer/primitives@^7.0.1", "@primer/primitives@^7.2.0":
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/@primer/primitives/-/primitives-7.3.0.tgz#8e362465fa641ae8c840205e3c296635279c5786"
-  integrity sha512-A8iG4wL7jaSKWYnV/47IEsnNrKM4ZKgcFQba1rvOmuXBdCugmK3Iw/iskSy/CworC+rU/3fy5Z54hvilRxGM1w==
+"@primer/primitives@^7.0.1":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@primer/primitives/-/primitives-7.4.0.tgz#75df54a80233a432b687c0e3010e4be6bd60a82d"
+  integrity sha512-gD6yHXN7YKox/bdUNgxhoSS/WXZVaORK1r4dOAyTrdoPrLV/ucIfRInPyVcTF+Mqr0zcTFJtiMtuA5Y8CSyOEg==
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
@@ -4048,6 +4041,15 @@ postcss-value-parser@^4.0.2, postcss-value-parser@^4.1.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
+postcss@8.4.5:
+  version "8.4.5"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.5.tgz#bae665764dfd4c6fcc24dc0fdf7e7aa00cc77f95"
+  integrity sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==
+  dependencies:
+    nanoid "^3.1.30"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.1"
+
 postcss@^8.2.4, postcss@^8.3.11, postcss@^8.3.6:
   version "8.3.11"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.3.11.tgz#c3beca7ea811cd5e1c4a3ec6d2e7599ef1f8f858"
@@ -4411,6 +4413,11 @@ source-map-js@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-0.6.2.tgz#0bb5de631b41cfbda6cfba8bd05a80efdfd2385e"
   integrity sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==
+
+source-map-js@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.1.tgz#a1741c131e3c77d048252adfa24e23b908670caf"
+  integrity sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA==
 
 source-map-support@^0.5.6:
   version "0.5.20"


### PR DESCRIPTION
I discovered a circular dependency between `stylelint-config` and `primer-css` as I'm experimenting with different tooling:
` WARN  @primer/stylelint-config@12.2.0 requires a peer of @primer/css@>= 18.0.0 but none was installed.` (from primer-css package)

Since `stylelint-config` is designed to be consumed by `primer-css` and other libraries/codebases, I don't think it should depend on `primer-css`.

Removing this breaks `no-override.js` which seems to be references something from `primer-css` dist. Wondering if we can find a workaround?

![image](https://user-images.githubusercontent.com/18661030/147705261-7fc4b6b4-e9ba-434b-a2cd-c8d31ce3764f.png)
