### PR TITLE
Fixing an issue where the new spacing plugin isn't traversing child sectors.

### DIFF
--- a/.changeset/beige-chefs-speak.md
+++ b/.changeset/beige-chefs-speak.md
@@ -1,0 +1,5 @@
+---
+"@primer/stylelint-config": patch
+---
+
+Fixing an issue where the new spacing plugin isn't traversing child sectors.

--- a/__tests__/spacing.js
+++ b/__tests__/spacing.js
@@ -112,21 +112,24 @@ testRule({
           line: 1,
           rule: 'primer/spacing',
           severity: 'error',
-          message: "Please use a primer spacer variable instead of '3px'. Consult the primer docs for a suitable replacement. https://primer.style/css/support/spacing (primer/spacing)"
+          message:
+            "Please use a primer spacer variable instead of '3px'. Consult the primer docs for a suitable replacement. https://primer.style/css/support/spacing (primer/spacing)"
         },
         {
           column: 34,
           line: 1,
           rule: 'primer/spacing',
           severity: 'error',
-          message: "Please use a primer spacer variable instead of '3px'. Consult the primer docs for a suitable replacement. https://primer.style/css/support/spacing (primer/spacing)"
+          message:
+            "Please use a primer spacer variable instead of '3px'. Consult the primer docs for a suitable replacement. https://primer.style/css/support/spacing (primer/spacing)"
         },
         {
           column: 53,
           line: 1,
           rule: 'primer/spacing',
           severity: 'error',
-          message: "Please use a primer spacer variable instead of '3px'. Consult the primer docs for a suitable replacement. https://primer.style/css/support/spacing (primer/spacing)"
+          message:
+            "Please use a primer spacer variable instead of '3px'. Consult the primer docs for a suitable replacement. https://primer.style/css/support/spacing (primer/spacing)"
         }
       ]
     }

--- a/__tests__/spacing.js
+++ b/__tests__/spacing.js
@@ -31,6 +31,10 @@ testRule({
     {
       code: '.x { padding: calc(#{$spacer-4} * 2); }',
       description: 'Finds interpolated calc values.'
+    },
+    {
+      code: '.x { padding: $spacer-1; .y { padding: $spacer-1; } }',
+      description: 'Nested css works.'
     }
   ],
   reject: [
@@ -97,6 +101,34 @@ testRule({
       line: 1,
       column: 21,
       description: 'Errors on non-primer spacer in parens.'
+    },
+    {
+      code: '.x { padding: 3px; .y { padding: 3px; .z { padding: 3px; } } }',
+      unfixable: true,
+      description: 'Rejects nested CSS.',
+      warnings: [
+        {
+          column: 15,
+          line: 1,
+          rule: 'primer/spacing',
+          severity: 'error',
+          message: "Please use a primer spacer variable instead of '3px'. Consult the primer docs for a suitable replacement. https://primer.style/css/support/spacing (primer/spacing)"
+        },
+        {
+          column: 34,
+          line: 1,
+          rule: 'primer/spacing',
+          severity: 'error',
+          message: "Please use a primer spacer variable instead of '3px'. Consult the primer docs for a suitable replacement. https://primer.style/css/support/spacing (primer/spacing)"
+        },
+        {
+          column: 53,
+          line: 1,
+          rule: 'primer/spacing',
+          severity: 'error',
+          message: "Please use a primer spacer variable instead of '3px'. Consult the primer docs for a suitable replacement. https://primer.style/css/support/spacing (primer/spacing)"
+        }
+      ]
     }
   ]
 })

--- a/plugins/spacing.js
+++ b/plugins/spacing.js
@@ -41,7 +41,11 @@ module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}, contex
   }
 
   const lintResult = (root, result) => {
-    root.walkDecls(/^(padding|margin)/, decl => {
+    root.walk(decl => {
+      if (decl.type !== 'decl' || !decl.prop.match(/^(padding|margin)/)) {
+        return noop
+      }
+
       const problems = []
       let containsMath = false
       let conatinsVariable = false
@@ -53,7 +57,7 @@ module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}, contex
 
         // Ignore values that are not numbers.
         if (['0', 'auto', 'inherit', 'initial'].includes(declValue.value)) {
-          return false
+          return noop
         }
         // Remove leading negative sign, if any.
         const cleanDeclValue = declValue.value.replace(/^-/g, '')
@@ -65,13 +69,13 @@ module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}, contex
           )
         ) {
           conatinsVariable = true
-          return false
+          return noop
         }
 
         // For now we're going to ignore math.
         if (['*', '+', '-', '/'].includes(declValue.value)) {
           containsMath = true
-          return false
+          return noop
         }
 
         let valueMatch = null
@@ -97,7 +101,7 @@ module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}, contex
       }
 
       if (containsMath && conatinsVariable) {
-        return false
+        return noop
       }
 
       if (problems.length) {


### PR DESCRIPTION
I found that PostCSS's `walkDecl` doesn't walk recursively, so it's missing any declarations nested. I updated the plugin to walk everything and filter out what isn't `padding|margin`. 

✅ Tests added


```scss
.foo {
   padding: 2px; // It catches this
   .bar {
      padding: 2px; // but not this
   }
}
```