### PR TITLE
Making linter pick up separate function groups

### DIFF
--- a/.changeset/tender-eggs-rhyme.md
+++ b/.changeset/tender-eggs-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@primer/stylelint-config": patch
+---
+
+Making linter pick up separate function groups

--- a/__tests__/spacing.js
+++ b/__tests__/spacing.js
@@ -63,25 +63,21 @@ testRule({
       column: 20
     },
     {
-      code: `
-      .x {
-        padding: 6px ($spacer-3 + 12px + $spacer-2);
-      }
-      `,
+      code: '.x { padding: 6px ($spacer-3 + 12px + $spacer-2); }',
       unfixable: true,
       description: 'Complex calc expression.',
       warnings: [
         {
-          column: 18,
-          line: 3,
+          column: 15,
+          line: 1,
           rule: 'primer/spacing',
           severity: 'error',
           message:
             "Please use a primer spacer variable instead of '6px'. Consult the primer docs for a suitable replacement. https://primer.style/css/support/spacing (primer/spacing)"
         },
         {
-          column: 35,
-          line: 3,
+          column: 32,
+          line: 1,
           rule: 'primer/spacing',
           severity: 'error',
           message:

--- a/__tests__/spacing.js
+++ b/__tests__/spacing.js
@@ -63,6 +63,33 @@ testRule({
       column: 20
     },
     {
+      code: `
+      .x {
+        padding: 6px ($spacer-3 + 12px + $spacer-2);
+      }
+      `,
+      unfixable: true,
+      description: 'Complex calc expression.',
+      warnings: [
+        {
+          column: 18,
+          line: 3,
+          rule: 'primer/spacing',
+          severity: 'error',
+          message:
+            "Please use a primer spacer variable instead of '6px'. Consult the primer docs for a suitable replacement. https://primer.style/css/support/spacing (primer/spacing)"
+        },
+        {
+          column: 35,
+          line: 3,
+          rule: 'primer/spacing',
+          severity: 'error',
+          message:
+            "Please use a primer spacer variable instead of '12px'. Consult the primer docs for a suitable replacement. https://primer.style/css/support/spacing (primer/spacing)"
+        }
+      ]
+    },
+    {
       code: '.x { padding: 3px 4px; }',
       fixed: '.x { padding: 3px $spacer-1; }',
       description: "Replaces '4px' with '$spacer-1' and errors on '3px'.",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "plugins/"
   ],
   "scripts": {
-    "test": "jest",
+    "test": "jest --coverage false",
     "lint": "eslint .",
     "release": "changeset publish"
   },

--- a/plugins/spacing.js
+++ b/plugins/spacing.js
@@ -36,11 +36,11 @@ const messages = stylelint.utils.ruleMessages(ruleName, {
 })
 
 const walkGroups = (root, validate) => {
-  for (let node of root.nodes) {
+  for (const node of root.nodes) {
     if (node.type === 'function') {
-      node = walkGroups(node, validate)
+      walkGroups(node, validate)
     } else {
-      node = validate(node)
+      validate(node)
     }
   }
   return root
@@ -66,18 +66,18 @@ module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}, contex
 
         // Only check word types. https://github.com/TrySound/postcss-value-parser#word
         if (node.type !== 'word') {
-          return node
+          return
         }
 
         // Exact values to ignore.
         if (['*', '+', '-', '/', '0', 'auto', 'inherit', 'initial'].includes(node.value)) {
-          return node
+          return
         }
 
         const valueUnit = valueParser.unit(cleanValue)
 
         if (valueUnit && (valueUnit.unit === '' || !/^[0-9]+$/.test(valueUnit.number))) {
-          return node
+          return
         }
 
         // If the a variable is found in the value, skip it.
@@ -86,7 +86,7 @@ module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}, contex
             new RegExp(`${variable.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`).test(cleanValue)
           )
         ) {
-          return node
+          return
         }
 
         const replacement = Object.keys(spacerValues).find(spacer => spacerValues[spacer] === cleanValue) || null
@@ -101,7 +101,7 @@ module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}, contex
           })
         }
 
-        return node
+        return
       })
 
       if (context.fix) {


### PR DESCRIPTION
This PR fixes a case that was missing from the spacing plugin. In this example, the linter should fail on `6px` because it's separate from the math group happening.

I rewrote the walk function to recursively dive into each function group and evaluate the variables. This gives us more reliable results.

```scss
// This failed to be picked up by the linter before.
.x {
   padding: 6px ($spacer-3 + 12px + $spacer-2);
}
```