### PR TITLE
[Bug fix] Catching values with dots in them

### DIFF
--- a/.changeset/dull-glasses-visit.md
+++ b/.changeset/dull-glasses-visit.md
@@ -1,0 +1,5 @@
+---
+"@primer/stylelint-config": patch
+---
+
+[Bug fix] Catching values with dots in them

--- a/__tests__/spacing.js
+++ b/__tests__/spacing.js
@@ -39,12 +39,29 @@ testRule({
   ],
   reject: [
     {
+      code: '.x { padding-bottom: 0.3em; }',
+      unfixable: true,
+      message:
+        "Please use a primer spacer variable instead of '0.3em'. Consult the primer docs for a suitable replacement. https://primer.style/css/support/spacing (primer/spacing)",
+      line: 1,
+      column: 22,
+      description: 'Errors on non-spacer em values.'
+    },
+    {
       code: '.x { padding: 4px; }',
       fixed: '.x { padding: $spacer-1; }',
       message: `Please replace 4px with spacing variable '$spacer-1'. (primer/spacing)`,
       line: 1,
       column: 15,
       description: "Replaces '4px' with '$spacer-1'."
+    },
+    {
+      code: '.x { padding: 0.5em; }',
+      fixed: '.x { padding: $em-spacer-5; }',
+      message: `Please replace 0.5em with spacing variable '$em-spacer-5'. (primer/spacing)`,
+      line: 1,
+      column: 15,
+      description: "Replaces '0.5em' with '$em-spacer-5'."
     },
     {
       code: '.x { padding: -4px; }',

--- a/plugins/spacing.js
+++ b/plugins/spacing.js
@@ -76,7 +76,7 @@ module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}, contex
 
         const valueUnit = valueParser.unit(cleanValue)
 
-        if (valueUnit && (valueUnit.unit === '' || !/^[0-9]+$/.test(valueUnit.number))) {
+        if (valueUnit && (valueUnit.unit === '' || !/^[0-9.]+$/.test(valueUnit.number))) {
           return
         }
 


### PR DESCRIPTION
I found when upgrading that the last release was missing values with dots in them like `0.5` https://github.com/primer/css/pull/1956/files#diff-fe986252765f6a97978946e9a32e8946b267ea06df7534f06dc47c1c6578d94bL147

This adds 2 tests, and fixes the bug