### PR TITLE
Creating a responsive-widths plugin to keep fixed widths smaller than the minimum viewport size

### DIFF
--- a/.changeset/clean-seas-mate.md
+++ b/.changeset/clean-seas-mate.md
@@ -1,0 +1,5 @@
+---
+"@primer/stylelint-config": minor
+---
+
+Creating a responsive-widths plugin to keep fixed widths smaller than the minimum viewport size

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Primer Stylelint Config extends the [stylelint-config-standard](https://github.c
 - [primer/typography](./plugins/#primertypography): Enforces the use of typography variables for certain CSS properties.
 - [primer/borders](./plugins/#primerborders): Enforces the use of certain variables for border properties.
 - [primer/box-shadow](./plugins/#primerbox-shadow): Enforces the use of certain variables for `box-shadow`.
+- [primer/responsive-widths](./plugins/#primerresponsive-widths): Errors on `width` and `min-width` that is larger than the minimum browser size supported. `320px`
 
 ## License
 

--- a/__tests__/responsive-widths.js
+++ b/__tests__/responsive-widths.js
@@ -1,0 +1,57 @@
+const {ruleName} = require('../plugins/responsive-widths')
+
+// eslint-disable-next-line no-undef
+testRule({
+  plugins: ['./plugins/responsive-widths.js'],
+  customSyntax: 'postcss-scss',
+  ruleName,
+  config: [true],
+  accept: [
+    {
+      code: '.x { width: 319px; }',
+      description: 'Width is less than small viewport.'
+    },
+    {
+      code: '.x { width: 100%; }',
+      description: 'Width is 100% or less.'
+    },
+    {
+      code: '.x { min-width: 319px; }',
+      description: 'Min-width is less than small viewport.'
+    },
+    {
+      code: '.x { max-width: 1000px; }',
+      description: 'Max-width larger than small viewport.'
+    },
+    {
+      code: '.x { width: calc(10px + 10px); }',
+      description: 'Max-width larger than small viewport.'
+    }
+  ],
+  reject: [
+    {
+      code: '.x { width: 325px; }',
+      message:
+        'A value larger than the smallest viewport could break responsive pages. Use a width value smaller than 325px. https://primer.style/css/support/breakpoints (primer/responsive-widths)',
+      line: 1,
+      column: 13,
+      description: 'Errors on width greater than minimum size.'
+    },
+    {
+      code: '.x { min-width: 325px; }',
+      message:
+        'A value larger than the smallest viewport could break responsive pages. Use a width value smaller than 325px. https://primer.style/css/support/breakpoints (primer/responsive-widths)',
+      line: 1,
+      column: 17,
+      description: 'Errors on min-width greater than minimum size.'
+    },
+    {
+      code: '.x { width: 300%; }',
+      message:
+        'A value larger than the smallest viewport could break responsive pages. Use a width value smaller than 300%. https://primer.style/css/support/breakpoints (primer/responsive-widths)',
+      line: 1,
+      column: 13,
+      description: 'Errors on percentage width greater than 100%.'
+    }
+  ]
+})

--- a/__tests__/responsive-widths.js
+++ b/__tests__/responsive-widths.js
@@ -12,8 +12,8 @@ testRule({
       description: 'Width is less than small viewport.'
     },
     {
-      code: '.x { width: 100%; }',
-      description: 'Width is 100% or less.'
+      code: '.x { width: 100vw; }',
+      description: 'Width is 100vw or less.'
     },
     {
       code: '.x { min-width: 319px; }',
@@ -26,6 +26,10 @@ testRule({
     {
       code: '.x { width: calc(10px + 10px); }',
       description: 'Max-width larger than small viewport.'
+    },
+    {
+      code: '.x { @include breakpoint(md) { width: 500px; } }',
+      description: 'Ignore widths inside breakpoint.'
     }
   ],
   reject: [
@@ -46,12 +50,12 @@ testRule({
       description: 'Errors on min-width greater than minimum size.'
     },
     {
-      code: '.x { width: 300%; }',
+      code: '.x { width: 300vw; }',
       message:
-        'A value larger than the smallest viewport could break responsive pages. Use a width value smaller than 300%. https://primer.style/css/support/breakpoints (primer/responsive-widths)',
+        'A value larger than the smallest viewport could break responsive pages. Use a width value smaller than 300vw. https://primer.style/css/support/breakpoints (primer/responsive-widths)',
       line: 1,
       column: 13,
-      description: 'Errors on percentage width greater than 100%.'
+      description: 'Errors on viewport width greater than 100.'
     }
   ]
 })

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ module.exports = {
     './plugins/borders',
     './plugins/box-shadow',
     './plugins/colors',
+    './plugins/responsive-widths',
     './plugins/spacing',
     './plugins/typography'
   ],
@@ -64,6 +65,7 @@ module.exports = {
       {severity: 'warning', files: 'node_modules/@primer/primitives/dist/scss/colors*/*.scss'}
     ],
     'primer/no-unused-vars': [true, {severity: 'warning'}],
+    'primer/responsive-widths': true,
     'primer/spacing': true,
     'primer/typography': true,
     'scss/at-extend-no-missing-placeholder': true,

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -17,6 +17,7 @@ This directory contains all of our custom stylelint plugins, each of which provi
   - [`primer/typography`](#primertypography)
   - [`primer/borders`](#primerborders)
   - [`primer/box-shadow`](#primerbox-shadow)
+  - [`primer/responsive-widths`](#primerresponsive-widths)
   - [Variable rules](#variable-rules)
     - [Variable rule options](#variable-rule-options)
 
@@ -206,6 +207,10 @@ This [variable rule](#variable-rules) enforces the use of border-specific variab
 ## `primer/box-shadow`
 
 This [variable rule](#variable-rules) enforces the use of `$box-shadow*` variables for the `box-shadow` CSS property. See [the configuration](./box-shadow.js) for more info.
+
+## `primer/responsive-widths`
+
+This plugin checks for `width` and `min-width` declarations that use a value less than the minimum browser size. `320px`
 
 ## Variable rules
 

--- a/plugins/responsive-widths.js
+++ b/plugins/responsive-widths.js
@@ -1,0 +1,93 @@
+const stylelint = require('stylelint')
+const declarationValueIndex = require('stylelint/lib/utils/declarationValueIndex')
+const valueParser = require('postcss-value-parser')
+
+const ruleName = 'primer/responsive-widths'
+
+const messages = stylelint.utils.ruleMessages(ruleName, {
+  rejected: value => {
+    return `A value larger than the smallest viewport could break responsive pages. Use a width value smaller than ${value}. https://primer.style/css/support/breakpoints`
+  }
+})
+
+// 320px is the smallest viewport size that we support
+
+const walkGroups = (root, validate) => {
+  for (const node of root.nodes) {
+    if (node.type === 'function') {
+      walkGroups(node, validate)
+    } else {
+      validate(node)
+    }
+  }
+  return root
+}
+
+// eslint-disable-next-line no-unused-vars
+module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}, context) => {
+  if (!enabled) {
+    return noop
+  }
+
+  const lintResult = (root, result) => {
+    root.walk(decl => {
+      if (decl.type !== 'decl' || !decl.prop.match(/^(min-width|width)/)) {
+        return noop
+      }
+
+      const problems = []
+
+      walkGroups(valueParser(decl.value), node => {
+        // Only check word types. https://github.com/TrySound/postcss-value-parser#word
+        if (node.type !== 'word') {
+          return
+        }
+
+        // Exact values to ignore.
+        if (['*', '+', '-', '/', '0', 'auto', 'inherit', 'initial'].includes(node.value)) {
+          return
+        }
+
+        const valueUnit = valueParser.unit(node.value)
+
+        switch (valueUnit.unit) {
+          case 'px':
+            if (parseInt(valueUnit.number) > 320) {
+              problems.push({
+                index: declarationValueIndex(decl) + node.sourceIndex,
+                message: messages.rejected(node.value)
+              })
+            }
+            break
+          case '%':
+            if (parseInt(valueUnit.number) > 100) {
+              problems.push({
+                index: declarationValueIndex(decl) + node.sourceIndex,
+                message: messages.rejected(node.value)
+              })
+            }
+            break
+        }
+      })
+
+      if (problems.length) {
+        for (const err of problems) {
+          stylelint.utils.report({
+            index: err.index,
+            message: err.message,
+            node: decl,
+            result,
+            ruleName
+          })
+        }
+      }
+    })
+  }
+
+  return lintResult
+})
+
+function noop() {}
+
+module.exports.ruleName = ruleName
+module.exports.messages = messages

--- a/plugins/responsive-widths.js
+++ b/plugins/responsive-widths.js
@@ -31,6 +31,11 @@ module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}, contex
 
   const lintResult = (root, result) => {
     root.walk(decl => {
+      // Ignore things inside of breakpoints
+      if (decl.type === 'atrule' && decl.name === 'include' && decl.params.includes('breakpoint')) {
+        return false
+      }
+
       if (decl.type !== 'decl' || !decl.prop.match(/^(min-width|width)/)) {
         return noop
       }
@@ -59,7 +64,7 @@ module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}, contex
               })
             }
             break
-          case '%':
+          case 'vw':
             if (parseInt(valueUnit.number) > 100) {
               problems.push({
                 index: declarationValueIndex(decl) + node.sourceIndex,


### PR DESCRIPTION
This PR creates a new plugin that will throw an error when we're using `width` or `min-width` with a size that's larger than our minimum browser size. This is because it could cause problems with responsive pages.

closes https://github.com/github/primer/issues/741

```css
/* pass */

.foo {
  max-width: 800px;
}

.foo {
  width: 20px;
}

/* fail */
.foo {
  width: 800px;
}

.foo {
  min-width: 800px;
}
```