### PR TITLE
Fixing issue in utilities plugin

### DIFF
--- a/.changeset/large-lemons-arrive.md
+++ b/.changeset/large-lemons-arrive.md
@@ -1,0 +1,5 @@
+---
+"@primer/stylelint-config": patch
+---
+
+Fixing issue in utilities plugin that missed certain classes

--- a/__tests__/utilities.js
+++ b/__tests__/utilities.js
@@ -30,6 +30,14 @@ testRule({
       description: 'Errors on spacer utility.'
     },
     {
+      code: '.x { padding: 1px; &:hover { padding:2px; } } .x { padding: $spacer-4; }',
+      message:
+        "Consider using the Primer utility '.p-4' instead of the selector '.x' in your html. https://primer.style/css/utilities (primer/utilities)",
+      line: 1,
+      column: 47,
+      description: 'Errors on spacer utility with hover ampersand.'
+    },
+    {
       code: '.x { padding: $spacer-4 !important; }',
       message:
         "Consider using the Primer utility '.p-4' instead of the selector '.x' in your html. https://primer.style/css/utilities (primer/utilities)",

--- a/plugins/utilities.js
+++ b/plugins/utilities.js
@@ -27,7 +27,7 @@ module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}, contex
   const lintResult = (root, result) => {
     root.walkRules(rule => {
       if (!/^\.[\w\-_]+$/.exec(rule.selector)) {
-        return false
+        return
       }
       const decls = rule.nodes.filter(decl => decl.type === 'decl')
 


### PR DESCRIPTION
I was noticing that the plugin was missing some cases in practice. For example it would miss the `.foo` class in the example below.

```scss
body {
  font-size: 12px;
}

.foo {
  margin-top: $spacer-1;
}
```

[Example in code](https://github.com/github/github/blob/261186ffa9a04f916c0c1ee7f4b3f26c956b64ff/app/assets/stylesheets/bundles/github/integrations.scss#L16)

This was because of the `return false` in my selector check. This was stopping the processing of the rest of the page when it happened. 

I added a test case for this bug.