### PR TITLE
allow for vars defined in scope, or within :root/:host selectors in file

### DIFF
--- a/.changeset/cold-cooks-taste.md
+++ b/.changeset/cold-cooks-taste.md
@@ -1,0 +1,5 @@
+---
+"@primer/stylelint-config": minor
+---
+
+allow for vars defined in scope, or within :root/:host selectors in file

--- a/__tests__/no-undefined-vars.js
+++ b/__tests__/no-undefined-vars.js
@@ -25,7 +25,53 @@ testRule({
     {code: '.x { margin: var(--spacing-spacer-1); }'},
     {
       code: '@include color-variables(\n  (\n    (feature-bg-color, (light: var(--color-scale-blue-1), dark: var(--color-scale-blue-2)))));'
-    }
+    },
+    {
+      code: `
+        .x {
+          --color-foo: #ffeeee;
+        }
+      `
+    },
+    {
+      code: `
+        .x {
+          --color-foo: #ffeeee;
+          color: var(--color-foo);
+        }
+      `
+    },
+    {
+      code: `
+        :root {
+          --color-foo: #ffeeee;
+        }
+        .x {
+          color: var(--color-foo);
+        }
+      `
+    },
+    {
+      code: `
+        :host {
+          --color-foo: #ffeeee;
+        }
+        .x {
+          color: var(--color-foo);
+        }
+      `
+    },
+    {
+      code: `
+        :root {
+          --color-foo: #ffeeee;
+        }
+        .x {
+          --color-bar: var(--color-foo);
+          color: var(--color-bar);
+        }
+      `
+    },
   ],
 
   reject: [
@@ -60,6 +106,30 @@ testRule({
       message: messages.rejected('--color-bar'),
       line: 1,
       column: 6
+    },
+    {
+      code: '.x { --color-bar: #000000; } .y { color: var(--color-bar); }',
+      message: messages.rejected('--color-bar'),
+      line: 1,
+      column: 35
+    },
+    {
+      code: '.x { --color-foo: #000000; color: var(--color-bar); }',
+      message: messages.rejected('--color-bar'),
+      line: 1,
+      column: 28
+    },
+    {
+      code: ':root { --color-foo: #000000 } .x { color: var(--color-bar); }',
+      message: messages.rejected('--color-bar'),
+      line: 1,
+      column: 37
+    },
+    {
+      code: ':host { --color-foo: #000000 } .x { color: var(--color-bar); }',
+      message: messages.rejected('--color-bar'),
+      line: 1,
+      column: 37
     },
     {
       code: '@include color-variables(\n  (\n    (feature-bg-color, (light: var(--color-scale-blue-1), dark: var(--color-fake-2)))));',

--- a/__tests__/no-undefined-vars.js
+++ b/__tests__/no-undefined-vars.js
@@ -71,7 +71,7 @@ testRule({
           color: var(--color-bar);
         }
       `
-    },
+    }
   ],
 
   reject: [

--- a/plugins/no-undefined-vars.js
+++ b/plugins/no-undefined-vars.js
@@ -77,7 +77,11 @@ module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}) => {
         }
 
         for (const [, variableName] of matchAll(decl.value, variableReferenceRegex)) {
-          checkVariable(variableName, decl, new Set([...globalDefinedVariables, ...fileDefinedVariables, ...scopeDefinedVaribles]))
+          checkVariable(
+            variableName,
+            decl,
+            new Set([...globalDefinedVariables, ...fileDefinedVariables, ...scopeDefinedVaribles])
+          )
         }
       })
     })

--- a/plugins/no-undefined-vars.js
+++ b/plugins/no-undefined-vars.js
@@ -27,14 +27,15 @@ module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}) => {
   const {files = ['**/*.scss', '!node_modules'], verbose = false} = options
   // eslint-disable-next-line no-console
   const log = verbose ? (...args) => console.warn(...args) : noop
-  const definedVariables = getDefinedVariables(files, log)
-
+  const globalDefinedVariables = getDefinedVariables(files, log)
   // Keep track of declarations we've already seen
   const seen = new WeakMap()
 
   return (root, result) => {
-    function checkVariable(variableName, node) {
-      if (!definedVariables.has(variableName)) {
+    const fileDefinedVariables = new Set()
+
+    function checkVariable(variableName, node, allowed) {
+      if (!allowed.has(variableName)) {
         stylelint.utils.report({
           message: messages.rejected(variableName),
           node,
@@ -52,13 +53,23 @@ module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}) => {
         }
 
         for (const [, variableName] of innerMatch) {
-          checkVariable(variableName, rule)
+          checkVariable(variableName, rule, new Set([...globalDefinedVariables, ...fileDefinedVariables]))
         }
       }
     })
 
     root.walkRules(rule => {
+      const scopeDefinedVaribles = new Set()
+
       rule.walkDecls(decl => {
+        // Add CSS variable declarations within the source text to the list of allowed variables
+        if (decl.prop.startsWith('--')) {
+          scopeDefinedVaribles.add(decl.prop)
+          if (decl.parent.selector === ':root' || decl.parent.selector === ':host') {
+            fileDefinedVariables.add(decl.prop)
+          }
+        }
+
         if (seen.has(decl)) {
           return
         } else {
@@ -66,7 +77,7 @@ module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}) => {
         }
 
         for (const [, variableName] of matchAll(decl.value, variableReferenceRegex)) {
-          checkVariable(variableName, decl)
+          checkVariable(variableName, decl, new Set([...globalDefinedVariables, ...fileDefinedVariables, ...scopeDefinedVaribles]))
         }
       })
     })


### PR DESCRIPTION
This expands the `no-undefined-vars` rule to allow for variables that are defined in a local scope, like:

```css
.x {
  --color-foo: #ffeeee;
  color: var(--color-foo);
}
```

This allows developers to use variables defined in locally scoped components, which can be useful for imperatively altering them using the JavaScript APIs, without changing the specific properties they are referred in. So for example this can be useful when using calc or min/max for a specific component:

```css
.x {
  --min-margin: 100px;
  margin-bottom: max(--min-margin, 1vh);
}
```
```js
// allows for changing minimum value without overriding actual value
embiggen.addEventListener('click', () => $('.x').setProperty('--min-margin', '200px'))
```

However this _does not allow_ for undefined vars of a different scope:

```css
.x {
  --color-foo: #ffeeee;
}
.y {
  color: var(--color-foo); // this will still fail.
}
```

It also allows for a file to define its _own_ global variables, which can be either global to the `:host` (for shadow roots) or `:root` (for documents). These definitions can only be _file_ local, so the following now works:

```css
/* my-component.css */
:root {
  --my-component-color: #ffeeee;
}
.my-component {
  color: var(--my-component-color);
  background: white;
}
.my-component.flipped {
  background: var(--my-component-color);
  color: white;
}
```

However specifying variables that exist cross file _will still error, unless defined per usual in the rules config_:

```css
/* my-first-component.css */
:root {
  --my-component-color: #ffeeee;
}

/* my-other-component.css */
.x { color: --my-component-color: #ffeeee; } // still fails
```
