### PR TITLE
Add `bgColor-inset` fallback for Primitives v8

### DIFF
--- a/.changeset/slimy-files-relate.md
+++ b/.changeset/slimy-files-relate.md
@@ -1,0 +1,5 @@
+---
+"@primer/stylelint-config": patch
+---
+
+Add `bgColor-inset` fallback for Primitives v8

--- a/plugins/lib/primitives-v8.json
+++ b/plugins/lib/primitives-v8.json
@@ -876,7 +876,7 @@
   "--color-canvas-inset": [
     {
       "props": ["background"],
-      "replacement": "--bgColor-muted"
+      "replacement": "--bgColor-inset"
     }
   ],
   "--color-canvas-subtle": [


### PR DESCRIPTION
`inset` is back! This adds it as a proper fallback. 