### PR TITLE
Update config to alloy nesting in css modules

### DIFF
--- a/.changeset/giant-kangaroos-provide.md
+++ b/.changeset/giant-kangaroos-provide.md
@@ -1,0 +1,5 @@
+---
+"@primer/stylelint-config": minor
+---
+
+Update config to alloy nesting in css modules

--- a/__tests__/__fixtures__/good/example.module.css
+++ b/__tests__/__fixtures__/good/example.module.css
@@ -133,12 +133,10 @@
 }
 
 .details {
-  /* stylelint-disable-next-line max-nesting-depth */
   &[open] .down-icon {
     display: none !important;
   }
 
-  /* stylelint-disable-next-line max-nesting-depth */
   &:not([open]) .up-icon {
     display: none !important;
   }

--- a/index.js
+++ b/index.js
@@ -179,8 +179,6 @@ export default {
     {
       files: ['**/*.module.css'],
       rules: {
-        // Don't support nesting until it's more broadly shipped
-        'max-nesting-depth': [0],
         'property-no-unknown': [
           true,
           {
@@ -210,6 +208,7 @@ export default {
         'primer/typography': null,
         'primer/box-shadow': null,
         'primer/utilities': null,
+        'scss/selector-no-redundant-nesting-selector': null,
       },
     },
   ],

--- a/index.js
+++ b/index.js
@@ -208,7 +208,6 @@ export default {
         'primer/typography': null,
         'primer/box-shadow': null,
         'primer/utilities': null,
-        'scss/selector-no-redundant-nesting-selector': null,
       },
     },
   ],


### PR DESCRIPTION
Allow css nesting in stylelint config for `*.module.css` files