### PR TITLE
Trying to replace --space tokens as well

### DIFF
--- a/.changeset/flat-candles-complain.md
+++ b/.changeset/flat-candles-complain.md
@@ -1,0 +1,5 @@
+---
+"@primer/stylelint-config": patch
+---
+
+Add test to catch deprecated space tokens

--- a/__tests__/spacing.js
+++ b/__tests__/spacing.js
@@ -245,6 +245,15 @@ testRule({
       endColumn: 39,
       description: 'CSS > Errors on non-primer spacer in parens.',
     },
+    {
+      code: '.x { padding: var(--space-small); }',
+      unfixable: true,
+      message: messages.rejected('--space-small'),
+      line: 1,
+      column: 29,
+      endColumn: 39,
+      description: 'CSS > Errors on deprecated primer space tokens.',
+    },
   ],
 })
 

--- a/__tests__/spacing.js
+++ b/__tests__/spacing.js
@@ -24,7 +24,7 @@ testRule({
       description: 'CSS > Works on property partial match.',
     },
     {
-      code: '.x { padding: var(--base-size-4) var(--base-size-8); }',
+      code: '.x { gap: var(--base-size-4) var(--base-size-8); }',
       description: 'CSS > Two variables are valid.',
     },
     {
@@ -246,13 +246,22 @@ testRule({
       description: 'CSS > Errors on non-primer spacer in parens.',
     },
     {
-      code: '.x { padding: var(--space-small); }',
+      code: '.x { gap: var(--space-small); }',
       unfixable: true,
       message: messages.rejected('--space-small'),
       line: 1,
       column: 29,
       endColumn: 39,
-      description: 'CSS > Errors on deprecated primer space tokens.',
+      description: 'CSS > Errors on gap property with non-primer spacer.',
+    },
+    {
+      code: '.x { grid-gap: 12px; }',
+      unfixable: true,
+      message: messages.rejected('--space-small'),
+      line: 1,
+      column: 29,
+      endColumn: 39,
+      description: 'CSS > Errors on gap property with pixel value.',
     },
   ],
 })

--- a/plugins/spacing.js
+++ b/plugins/spacing.js
@@ -38,7 +38,7 @@ const meta = {
 const ruleFunction = (primary, secondaryOptions, context) => {
   return async (root, result) => {
     // Props that we want to check
-    const propList = ['padding', 'margin', 'top', 'right', 'bottom', 'left']
+    const propList = ['padding', 'margin', 'top', 'right', 'bottom', 'left', 'gap', 'grid-gap']
     // Values that we want to ignore
     const valueList = ['${']
 


### PR DESCRIPTION
This PR should make style lint replace `--space-...` tokens with `--base-size-...` tokens

Hey @jonrohan,

I am getting an error when trying to run `npm run build`:

```bash
❯ npm run build

> @primer/stylelint-config@12.9.2 build
> rollup -c

[!] SyntaxError: Unexpected token 'with'
    at ModuleLoader.moduleStrategy (node:internal/modules/esm/translators:118:18)
    at callTranslator (node:internal/modules/esm/loader:265:14)
    at ModuleLoader.moduleProvider (node:internal/modules/esm/loader:270:30)
    at link (node:internal/modules/esm/module_job:76:21)
```

Any idea how I can fix this?