### PR TITLE
Remove --space from example.module.css

### DIFF
--- a/__tests__/__fixtures__/good/example.module.css
+++ b/__tests__/__fixtures__/good/example.module.css
@@ -128,7 +128,7 @@
   width: var(--container-size);
   height: var(--container-size);
   /* stylelint-disable-next-line primer/spacing */
-  padding: var(--space-xsmall);
+  padding: var(--mySpace-xsmall);
 }
 
 .marketplace-logo--large {


### PR DESCRIPTION
We don't want to encourage use of `--space-x`