### PR TITLE
Force install postcss-modules-local-by-default@4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5933,35 +5933,14 @@
       }
     },
     "node_modules/icss-utils": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-4.1.1.tgz",
-      "integrity": "sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==",
-      "dependencies": {
-        "postcss": "^7.0.14"
-      },
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
+      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
       "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/icss-utils/node_modules/picocolors": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA=="
-    },
-    "node_modules/icss-utils/node_modules/postcss": {
-      "version": "7.0.39",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-      "dependencies": {
-        "picocolors": "^0.2.1",
-        "source-map": "^0.6.1"
+        "node": "^10 || ^12 || >= 14"
       },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
+      "peerDependencies": {
+        "postcss": "^8.1.0"
       }
     },
     "node_modules/ignore": {
@@ -8206,38 +8185,19 @@
       "license": "MIT"
     },
     "node_modules/postcss-modules-local-by-default": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-3.0.3.tgz",
-      "integrity": "sha512-e3xDq+LotiGesympRlKNgaJ0PCzoUIdpH0dj47iWAui/kyTgh3CiAr1qP54uodmJhl6p9rN6BoNcdEDVJx9RDw==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.5.tgz",
+      "integrity": "sha512-6MieY7sIfTK0hYfafw1OMEG+2bg8Q1ocHCpoWLqOKj3JXlKu4G7btkmM/B7lFubYkYWmRSPLZi5chid63ZaZYw==",
       "dependencies": {
-        "icss-utils": "^4.1.1",
-        "postcss": "^7.0.32",
+        "icss-utils": "^5.0.0",
         "postcss-selector-parser": "^6.0.2",
         "postcss-value-parser": "^4.1.0"
       },
       "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/postcss-modules-local-by-default/node_modules/picocolors": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA=="
-    },
-    "node_modules/postcss-modules-local-by-default/node_modules/postcss": {
-      "version": "7.0.39",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-      "dependencies": {
-        "picocolors": "^0.2.1",
-        "source-map": "^0.6.1"
+        "node": "^10 || ^12 || >= 14"
       },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
+      "peerDependencies": {
+        "postcss": "^8.1.0"
       }
     },
     "node_modules/postcss-resolve-nested-selector": {
@@ -9601,6 +9561,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
   },
   "overrides": {
     "stylelint-css-modules-no-global-scoped-selector": {
-      "stylelint": "$stylelint"
+      "stylelint": "$stylelint",
+      "postcss-modules-local-by-default": "^4.0.0"
     }
   },
   "prettier": "@github/prettier-config",


### PR DESCRIPTION
- Fixes https://github.com/github/primer/issues/3693

[stylelint-css-modules-no-global-scoped-selector@^1.0.2](https://github.com/primer/stylelint-config/blob/main/package.json) depends on postcss^7 which has certain [security vulnerabilities](https://github.com/github/primer/issues/3693)

However, there is no new version of stylelint-css-modules-no-global-scoped-selector since [Nov 6, 2021](https://github.com/lmichelin/stylelint-css-modules-no-global-scoped-selector/commits/master/), so we need to override one of its internal dependencies (`postcss-modules-local-by-default`) to a secure version that uses postcss^8