### PR TITLE
Stylelint fixes based on feedback

### DIFF
--- a/.changeset/weak-walls-stare.md
+++ b/.changeset/weak-walls-stare.md
@@ -1,0 +1,9 @@
+---
+"@primer/stylelint-config": patch
+---
+
+Stylelint fixes based on feedback:
+
+- `font-style` should allow keywords, `italic, normal`
+- border should allow `none` https://stylelint.io/user-guide/rules/declaration-property-value-disallowed-list
+- Update autofix in typography to always replace with the first suggestion

--- a/__tests__/typography.js
+++ b/__tests__/typography.js
@@ -43,6 +43,10 @@ testRule({
       code: '.x { font: var(--text-display-shorthand); }',
       description: 'CSS > Accepts font shorthand variables',
     },
+    {
+      code: '.x { font-style: italic; }',
+      description: 'CSS > Ignores font-style property',
+    },
   ],
   reject: [
     // Font sizes

--- a/__tests__/typography.js
+++ b/__tests__/typography.js
@@ -77,25 +77,15 @@ testRule({
       endColumn: 23,
       description: "CSS > Replaces '2.5rem' with 'var(--text-display-size)'.",
     },
-    {
-      code: '.x { font-size: 1.25rem; }',
-      unfixable: true,
-      message: messages.rejected('1.25rem', [{name: '--text-title-size-medium'}, {name: '--text-subtitle-size'}]),
-      line: 1,
-      column: 17,
-      endColumn: 24,
-      description: "CSS > Suggests list of variables to replace '1.25rem' with.",
-    },
     // Font weights
     {
       code: '.x { font-weight: 500; }',
-      unfixable: true,
-      message: messages.rejected('500', [{name: '--base-text-weight-medium'}, {name: '--text-display-weight'}]),
+      fixed: '.x { font-weight: var(--base-text-weight-medium); }',
+      message: messages.rejected('500', {name: '--base-text-weight-medium'}),
       line: 1,
       column: 19,
       endColumn: 22,
-      description:
-        "CSS > Errors on font-weight of 500 and suggests '--base-text-weight-medium' or '--text-display-weight'.",
+      description: "CSS > Errors on font-weight of 500 and suggests '--base-text-weight-medium'.",
     },
     {
       code: '.x { font-weight: 100; }',
@@ -108,18 +98,12 @@ testRule({
     },
     {
       code: '.x { font-weight: 800; }',
-      unfixable: true,
-      message: messages.rejected('800', [
-        {name: '--base-text-weight-semibold'},
-        {name: '--text-title-weight-large'},
-        {name: '--text-title-weight-medium'},
-        {name: '--text-title-weight-small'},
-      ]),
+      fixed: '.x { font-weight: var(--base-text-weight-semibold); }',
+      message: messages.rejected('800', {name: '--base-text-weight-semibold'}),
       line: 1,
       column: 19,
       endColumn: 22,
-      description:
-        "CSS > Errors on font-weight greater than 600 and suggests '--base-text-weight-semibold', '--text-title-weight-large', '--text-title-weight-medium', or '--text-title-weight-small'.",
+      description: "CSS > Errors on font-weight greater than 600 and suggests '--base-text-weight-semibold'.",
     },
     {
       code: '.x { font-weight: lighter; }',
@@ -132,50 +116,30 @@ testRule({
     },
     {
       code: '.x { font-weight: bold; }',
-      unfixable: true,
-      message: messages.rejected('bold', [
-        {name: '--base-text-weight-semibold'},
-        {name: '--text-title-weight-large'},
-        {name: '--text-title-weight-medium'},
-        {name: '--text-title-weight-small'},
-      ]),
+      fixed: '.x { font-weight: var(--base-text-weight-semibold); }',
+      message: messages.rejected('bold', {name: '--base-text-weight-semibold'}),
       line: 1,
       column: 19,
       endColumn: 23,
-      description:
-        "CSS > Errors on 'bold' font-weight keyword and suggests '--base-text-weight-semibold', '--text-title-weight-large', '--text-title-weight-medium', or '--text-title-weight-small'.",
+      description: "CSS > Errors on 'bold' font-weight keyword and suggests '--base-text-weight-semibold'.",
     },
     {
       code: '.x { font-weight: bolder; }',
-      unfixable: true,
-      message: messages.rejected('bolder', [
-        {name: '--base-text-weight-semibold'},
-        {name: '--text-title-weight-large'},
-        {name: '--text-title-weight-medium'},
-        {name: '--text-title-weight-small'},
-      ]),
+      fixed: '.x { font-weight: var(--base-text-weight-semibold); }',
+      message: messages.rejected('bolder', {name: '--base-text-weight-semibold'}),
       line: 1,
       column: 19,
       endColumn: 25,
-      description:
-        "CSS > Errors on 'bolder' font-weight keyword and suggests '--base-text-weight-semibold', '--text-title-weight-large', '--text-title-weight-medium', or '--text-title-weight-small'.",
+      description: "CSS > Errors on 'bolder' font-weight keyword and suggests '--base-text-weight-semibold'.",
     },
     {
       code: '.x { font-weight: normal; }',
-      unfixable: true,
-      message: messages.rejected('normal', [
-        {name: '--base-text-weight-normal'},
-        {name: '--text-subtitle-weight'},
-        {name: '--text-body-weight'},
-        {name: '--text-caption-weight'},
-        {name: '--text-codeBlock-weight'},
-        {name: '--text-codeInline-weight'},
-      ]),
+      fixed: '.x { font-weight: var(--base-text-weight-normal); }',
+      message: messages.rejected('normal', {name: '--base-text-weight-normal'}),
       line: 1,
       column: 19,
       endColumn: 25,
-      description:
-        "CSS > Errors on 'normal' font-weight keyword and suggests '--base-text-weight-normal', '--text-subtitle-weight', '--text-body-weight', '--text-caption-weight', '--text-codeBlock-weight' or '--text-codeInline-weight'.",
+      description: "CSS > Errors on 'normal' font-weight keyword and suggests '--base-text-weight-normal'.",
     },
     // Line heights
     {
@@ -198,17 +162,12 @@ testRule({
     },
     {
       code: '.x { line-height: 1.5; }',
-      unfixable: true,
-      message: messages.rejected('1.5', [
-        {name: '--text-title-lineHeight-large'},
-        {name: '--text-title-lineHeight-small'},
-        {name: '--text-body-lineHeight-large'},
-      ]),
+      fixed: '.x { line-height: var(--text-title-lineHeight-large); }',
+      message: messages.rejected('1.5', {name: '--text-title-lineHeight-large'}),
       line: 1,
       column: 19,
       endColumn: 22,
-      description:
-        "CSS > Errors on '1.5' line-height and suggests '--text-title-lineHeight-large', '--text-title-lineHeight-small', or '--text-body-lineHeight-large'.",
+      description: "CSS > Errors on '1.5' line-height and suggests '--text-title-lineHeight-large'.",
     },
     // Font family
     {

--- a/index.js
+++ b/index.js
@@ -65,7 +65,6 @@ export default {
     'declaration-property-value-disallowed-list': {
       '/^transition/': ['/all/'],
       '/^background/': ['http:', 'https:'],
-      '/^border/': ['none'],
       '/.+/': ['initial'],
     },
     'function-calc-no-unspaced-operator': true,

--- a/plugins/typography.js
+++ b/plugins/typography.js
@@ -72,7 +72,7 @@ for (const variable of variables) {
 }
 
 /** @type {import('stylelint').Rule} */
-const ruleFunction = (primary, secondaryOptions, context) => {
+const ruleFunction = primary => {
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
       actual: primary,

--- a/plugins/typography.js
+++ b/plugins/typography.js
@@ -27,7 +27,7 @@ export const messages = ruleMessages(ruleName, {
 
 const fontWeightKeywordMap = {
   normal: 400,
-  bold: 600,
+  bold: 700,
   bolder: 600,
   lighter: 300,
 }
@@ -140,10 +140,6 @@ const ruleFunction = (primary, secondaryOptions, context) => {
 
         if (!replacementTokens.length) {
           return
-        }
-
-        if (replacementTokens.length > 1) {
-          return replacementTokens
         }
 
         return replacementTokens[0]

--- a/plugins/typography.js
+++ b/plugins/typography.js
@@ -85,7 +85,7 @@ const ruleFunction = (primary, secondaryOptions, context) => {
     root.walkDecls(declNode => {
       const {prop, value} = declNode
 
-      if (!propList.some(typographyProp => prop.startsWith(typographyProp))) return
+      if (!propList.some(typographyProp => prop === typographyProp)) return
 
       const problems = []
 

--- a/plugins/typography.js
+++ b/plugins/typography.js
@@ -146,16 +146,20 @@ const ruleFunction = (primary, secondaryOptions, context) => {
       }
       const replacement = getReplacements()
       const fixable = replacement && !replacement.length
-
-      if (fixable && context.fix) {
-        declNode.value = value.replace(value, `var(${replacement['name']})`)
-      } else {
-        problems.push({
-          index: declarationValueIndex(declNode),
-          endIndex: declarationValueIndex(declNode) + value.length,
-          message: messages.rejected(value, replacement, prop),
-        })
+      let fixedValue = ''
+      if (fixable) {
+        fixedValue = value.replace(value, `var(${replacement['name']})`)
       }
+
+      problems.push({
+        index: declarationValueIndex(declNode),
+        endIndex: declarationValueIndex(declNode) + value.length,
+        message: messages.rejected(value, replacement, prop),
+        fix: () => {
+          if (!fixable) return
+          declNode.value = fixedValue
+        },
+      })
 
       if (problems.length) {
         for (const err of problems) {
@@ -166,6 +170,7 @@ const ruleFunction = (primary, secondaryOptions, context) => {
             node: declNode,
             result,
             ruleName,
+            fix: err.fix,
           })
         }
       }


### PR DESCRIPTION
Closes https://github.com/github/primer/issues/4009

This PR adjusts the rule set in the following ways:

- `font-style` should allow keywords, `italic, normal`
- border should allow `none` https://stylelint.io/user-guide/rules/declaration-property-value-disallowed-list
- Update autofix in typography to always replace with the first suggestion