### PR TITLE
Making fixes for primitives v10 rc

### DIFF
--- a/.changeset/polite-carrots-pay.md
+++ b/.changeset/polite-carrots-pay.md
@@ -1,0 +1,5 @@
+---
+"@primer/stylelint-config": patch
+---
+
+Making fixes for primitives v10 rc

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@changesets/changelog-github": "^0.5.0",
         "@changesets/cli": "2.27.9",
         "@github/prettier-config": "^0.0.6",
+        "@primer/primitives": "^10.0.0-rc.e5d395ea",
         "@rollup/plugin-commonjs": "^28.0.0",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^15.2.3",
@@ -1846,31 +1847,14 @@
         "url": "https://opencollective.com/unts"
       }
     },
-    "node_modules/@prettier/sync": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@prettier/sync/-/sync-0.5.2.tgz",
-      "integrity": "sha512-Yb569su456XNx5BsH/Vyem7xD6g/y9iLmLUzRKM1a/dhU/D7HqqvkAG72znulXlMXztbV0iiu9O5AL8K98TzZQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "make-synchronized": "^0.2.8"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier-synchronized?sponsor=1"
-      },
-      "peerDependencies": {
-        "prettier": "*"
-      }
-    },
     "node_modules/@primer/primitives": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-9.1.2.tgz",
-      "integrity": "sha512-KecRJpUdIf14J3gVpoyMMJeQD6Sh5kcHk93N5bYch4XGB0GOZP3ypxz+NByMjr/2HHPsRfCCO5EEgNjmeWYUGQ==",
+      "version": "10.0.0-rc.e5d395ea",
+      "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-10.0.0-rc.e5d395ea.tgz",
+      "integrity": "sha512-ag+iByu2Y6O8EfX1JumPhKAyxzSKuUXTr28w9IcRKifGGfaHit0pJdiwu6/9T74CLqVl8B178KnNneh1iDn0nQ==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@prettier/sync": "^0.5.2",
-        "prettier": "3.3"
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "^4.22.0"
       }
     },
     "node_modules/@rollup/plugin-commonjs": {
@@ -7117,16 +7101,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/make-synchronized": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/make-synchronized/-/make-synchronized-0.2.9.tgz",
-      "integrity": "sha512-4wczOs8SLuEdpEvp3vGo83wh8rjJ78UsIk7DIX5fxdfmfMJGog4bQzxfvOwq7Q3yCHLC4jp1urPHIxRS/A93gA==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/fisker/make-synchronized?sponsor=1"
-      }
-    },
     "node_modules/makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -7895,6 +7869,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
       "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@changesets/changelog-github": "^0.5.0",
     "@changesets/cli": "2.27.9",
     "@github/prettier-config": "^0.0.6",
+    "@primer/primitives": "^10.0.0-rc.e5d395ea",
     "@rollup/plugin-commonjs": "^28.0.0",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^15.2.3",

--- a/plugins/lib/utils.js
+++ b/plugins/lib/utils.js
@@ -31,11 +31,12 @@ export function primitivesVariables(type) {
     const data = require(`@primer/primitives/dist/styleLint/${file}`)
 
     for (const key of Object.keys(data)) {
-      const size = data[key]
-      const values = typeof size['value'] === 'string' ? [size['value']] : size['value']
+      const token = data[key]
+      const valueProp = '$value' in token ? '$value' : 'value'
+      const values = typeof token[valueProp] === 'string' ? [token[valueProp]] : token[valueProp]
 
       variables.push({
-        name: `--${size['name']}`,
+        name: `--${token['name']}`,
         values,
       })
     }


### PR DESCRIPTION
This updates to Primtives v10 release candidate and makes fixes that will be necessary based on dictionary changes.

**Note:** I'm adding `@primer/primitives` as a devDependency so that the build will not be ambiguous as to which version to test. This won't change any dependency graph in dotcom.