### PR TITLE
Add support for composite border variables and update variable sources

### DIFF
--- a/__tests__/borders.js
+++ b/__tests__/borders.js
@@ -21,6 +21,14 @@ testRule({
       description: 'CSS > Accepts border shorthand with variables',
     },
     {
+      code: '.x { border: var(--border-default); }',
+      description: 'CSS > Accepts border default variable shorthand',
+    },
+    {
+      code: '.x { border-left: var(--border-default); }',
+      description: 'CSS > Accepts border default variable directional longhand',
+    },
+    {
       code: '.x { border-width: var(--borderWidth-thin); }',
       description: 'CSS > Accepts border shorthand with variables',
     },

--- a/plugins/borders.js
+++ b/plugins/borders.js
@@ -30,6 +30,7 @@ export const messages = ruleMessages(ruleName, {
 const variables = primitivesVariables('border')
 const sizes = []
 const radii = []
+const compositeBorders = []
 
 // Props that we want to check
 const propList = ['border', 'border-width', 'border-radius']
@@ -55,6 +56,16 @@ for (const variable of variables) {
 
   if (name.includes('borderRadius')) {
     radii.push(variable)
+  }
+
+  // Composite border tokens (e.g., border-default, border-muted)
+  if (
+    name.startsWith('--border-') &&
+    !name.includes('borderWidth') &&
+    !name.includes('borderRadius') &&
+    !name.includes('borderColor')
+  ) {
+    compositeBorders.push(variable)
   }
 }
 
@@ -138,6 +149,10 @@ const ruleFunction = primary => {
         // If the variable is found in the value, skip it.
         if (prop.includes('width') || borderShorthand(prop)) {
           if (checkForVariable(sizes, node.value)) {
+            return
+          }
+          // Check for composite border variables on border shorthand
+          if (borderShorthand(prop) && checkForVariable(compositeBorders, node.value)) {
             return
           }
         }

--- a/plugins/lib/utils.js
+++ b/plugins/lib/utils.js
@@ -12,6 +12,7 @@ export function primitivesVariables(type) {
       break
     case 'border':
       files.push('functional/size/border.json')
+      files.push('functional/themes/light.json')
       break
     case 'typography':
       files.push('base/typography/typography.json')


### PR DESCRIPTION
Part of https://github.com/github/primer/issues/5736

This PR adds support for the `var(--border-default)` composite variable.