### PR TITLE
Warn on base typography token usage

### DIFF
--- a/__tests__/typography.js
+++ b/__tests__/typography.js
@@ -21,10 +21,6 @@ testRule({
     },
     // Font weights
     {
-      code: '.x { font-weight: var(--base-text-weight-semibold); }',
-      description: 'CSS > Accepts base font weight variables',
-    },
-    {
       code: '.x { font-weight: var(--text-title-weight-medium); }',
       description: 'CSS > Accepts functional font weight variables',
     },
@@ -49,6 +45,34 @@ testRule({
     },
   ],
   reject: [
+    // Base token warnings
+    {
+      code: '.x { font-weight: var(--base-text-weight-semibold); }',
+      unfixable: true,
+      message: messages.baseToken('var(--base-text-weight-semibold)'),
+      line: 1,
+      column: 19,
+      endColumn: 51,
+      description: 'CSS > Warns on base font weight variable',
+    },
+    {
+      code: '.x { font-size: var(--base-text-size-2xl); }',
+      unfixable: true,
+      message: messages.baseToken('var(--base-text-size-2xl)'),
+      line: 1,
+      column: 17,
+      endColumn: 42,
+      description: 'CSS > Warns on base font size variable',
+    },
+    {
+      code: '.x { line-height: var(--base-text-lineHeight-normal); }',
+      unfixable: true,
+      message: messages.baseToken('var(--base-text-lineHeight-normal)'),
+      line: 1,
+      column: 19,
+      endColumn: 53,
+      description: 'CSS > Warns on base line height variable',
+    },
     // Font sizes
     {
       code: '.x { font-size: 42px; }',

--- a/plugins/typography.js
+++ b/plugins/typography.js
@@ -23,6 +23,8 @@ export const messages = ruleMessages(ruleName, {
     // one possible replacement
     return `Please replace '${value}' with Primer typography variable '${replacement['name']}'. https://primer.style/foundations/primitives/typography`
   },
+  baseToken: value =>
+    `'${value}' is a base token. Consider using a functional Primer typography variable instead. https://primer.style/foundations/primitives/typography`,
 })
 
 const fontWeightKeywordMap = {
@@ -118,6 +120,18 @@ const ruleFunction = primary => {
       }
 
       if (checkForVariable(validValues, value)) {
+        // Warn when using base tokens (e.g. --base-text-weight-*) instead of functional tokens
+        if (/var\(--base-/.test(value)) {
+          report({
+            index: declarationValueIndex(declNode),
+            endIndex: declarationValueIndex(declNode) + value.length,
+            message: messages.baseToken(value),
+            node: declNode,
+            result,
+            ruleName,
+            severity: 'warning',
+          })
+        }
         return
       }
 
@@ -144,10 +158,13 @@ const ruleFunction = primary => {
       }
       const replacement = getReplacements()
       const fixable = replacement && !replacement.length
+      const isBaseTokenFix = fixable && replacement['name'].startsWith('--base-')
+      let didFix = false
       let fix = undefined
       if (fixable) {
         fix = () => {
           declNode.value = value.replace(value, `var(${replacement['name']})`)
+          didFix = true
         }
       }
 
@@ -160,6 +177,20 @@ const ruleFunction = primary => {
         ruleName,
         fix,
       })
+
+      // When auto-fix replaces a value with a base token, also report the base token warning
+      if (didFix && isBaseTokenFix) {
+        const newValue = declNode.value
+        report({
+          index: declarationValueIndex(declNode),
+          endIndex: declarationValueIndex(declNode) + newValue.length,
+          message: messages.baseToken(newValue),
+          node: declNode,
+          result,
+          ruleName,
+          severity: 'warning',
+        })
+      }
     })
   }
 }


### PR DESCRIPTION
## Motivation

Base typography tokens (`--base-text-weight-*`, `--base-text-size-*`, `--base-text-lineHeight-*`) are lower-level primitives. Users should prefer functional tokens (e.g. `--text-title-weight-medium`) for better semantic meaning and maintainability. Currently, base tokens are silently accepted — this PR surfaces a **warning** to nudge users toward functional alternatives without blocking their workflow.

## Approach

The `primer/typography` plugin now detects `var(--base-*)` values and reports them with `severity: 'warning'`. This means:

- **Functional tokens** (e.g. `--text-title-size-medium`) → accepted silently ✅
- **Base tokens** (e.g. `--base-text-weight-semibold`) → warning ⚠️ (informational, won't fail CI)
- **Hardcoded values** (e.g. `font-weight: 500`) → error ❌ (unchanged)

When auto-fix replaces a hardcoded value with a base token (e.g. `500` → `var(--base-text-weight-medium)`), the base token warning is also emitted so the user is aware the replacement is a base-level token.

## Changes

- **`plugins/typography.js`** — Added `baseToken` message, base token detection after variable validation, and post-fix warning emission
- **`__tests__/typography.js`** — Moved base token case from `accept` to `reject` with warning, added test cases for base font-size and line-height

---

Created with [GitHub Desktop](https://github.com/githubnext/copilot-tauri-app)